### PR TITLE
update to stop using deprecated django static files

### DIFF
--- a/fontawesome_5/app_settings.py
+++ b/fontawesome_5/app_settings.py
@@ -1,7 +1,7 @@
 import os
 
 from django.conf import settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 
 def get_prefix():


### PR DESCRIPTION
Fix for issue #1 
Required in order to work with django 3.0