### PR TITLE
add encoding for opening json file

### DIFF
--- a/fontawesome_5/utils.py
+++ b/fontawesome_5/utils.py
@@ -19,7 +19,7 @@ def get_icon_choices():
         'light': 'fal',
     }
 
-    with open(os.path.join(os.path.dirname(__file__), path)) as f:
+    with open(os.path.join(os.path.dirname(__file__), path), encoding='utf-8') as f:
         icons = json.load(f)
 
     for icon in icons:


### PR DESCRIPTION
Had an UnicodeDecodeError caused when the icons.json file got opened. Error appeared on a ubuntu 20.04 server. (python 3.8.5.) On a windows and ubuntu 20.04 desktop maschine it worked without the encoding.